### PR TITLE
Make performance.now behave more like real world

### DIFF
--- a/projects/ng-dev/package.json
+++ b/projects/ng-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sama/ng-dev",
-  "version": "20.0.0",
+  "version": "20.0.1",
   "author": "Samasource",
   "license": "MIT",
   "homepage": "https://github.com/Samasource/s-libs/tree/master/projects/ng-dev",

--- a/projects/ng-dev/src/lib/angular-context/angular-context.ts
+++ b/projects/ng-dev/src/lib/angular-context/angular-context.ts
@@ -260,7 +260,9 @@ export class AngularContext {
   #runWithMockedTime(test: VoidFunction): void {
     // https://github.com/angular/angular/issues/31677#issuecomment-573139551
     const { now } = performance;
-    spyOn(performance, 'now').and.callFake(() => Date.now());
+    spyOn(performance, 'now').and.callFake(
+      () => Date.now() - this.startTime.getTime(),
+    );
 
     jasmine.clock().install();
     fakeAsync(() => {


### PR DESCRIPTION
Jira story: ELF-488

## Description

performance.now starts at 0 instead of epoch.

## Security Checklist

- [ ] Verified that all input (HTML form fields, REST requests, URL parameters, HTTP headers, cookies, batch files, RSS feeds, etc) is validated using positive validation (allow lists). 

- [ ] Verified that data selection or database queries (e.g. SQL, HQL, ORM, NoSQL) use parameterized queries, ORMs, entity frameworks, or are otherwise protected from database injection attacks.

- [ ] Verified that output encoding is relevant for the interpreter and context required. For example, use encoders specifically for HTML values, HTML attributes, JavaScript, URL parameters, HTTP headers, SMTP, and others as the context requires, especially from untrusted inputs (e.g. names with Unicode or apostrophes, such as ねこ or O'Hara).

- [ ] Verified that key material is not exposed to the application but instead uses an isolated security module like a vault for cryptographic operations.
